### PR TITLE
- fixes issue with merged configs

### DIFF
--- a/src/Strategies/Settings.php
+++ b/src/Strategies/Settings.php
@@ -46,7 +46,7 @@ class Settings implements SettingsStrategyInterface
     const VALUE_ALLOW_ALL_HEADERS = '*';
 
     /** Settings key */
-    const KEY_SERVER_ORIGIN = 0;
+    const KEY_SERVER_ORIGIN = 'keyServerOrigin';
 
     /**
      * @deprecated Server Scheme is not used for `Host` header comparison anymore. You should remove it from settings.
@@ -62,31 +62,31 @@ class Settings implements SettingsStrategyInterface
     const KEY_SERVER_ORIGIN_PORT = 'port';
 
     /** Settings key */
-    const KEY_ALLOWED_ORIGINS = 1;
+    const KEY_ALLOWED_ORIGINS = 'keyAllowedOrigins';
 
     /** Settings key */
-    const KEY_ALLOWED_METHODS = 2;
+    const KEY_ALLOWED_METHODS = 'keyAllowedMethods';
 
     /** Settings key */
-    const KEY_ALLOWED_HEADERS = 3;
+    const KEY_ALLOWED_HEADERS = 'keyAllowedHeaders';
 
     /** Settings key */
-    const KEY_EXPOSED_HEADERS = 4;
+    const KEY_EXPOSED_HEADERS = 'keyExposedHeaders';
 
     /** Settings key */
-    const KEY_IS_USING_CREDENTIALS = 5;
+    const KEY_IS_USING_CREDENTIALS = 'keyIsUsingCredentials';
 
     /** Settings key */
-    const KEY_FLIGHT_CACHE_MAX_AGE = 6;
+    const KEY_FLIGHT_CACHE_MAX_AGE = 'keyFlightCacheMaxAge';
 
     /** Settings key */
-    const KEY_IS_FORCE_ADD_METHODS = 7;
+    const KEY_IS_FORCE_ADD_METHODS = 'keyIsForceAddMethods';
 
     /** Settings key */
-    const KEY_IS_FORCE_ADD_HEADERS = 8;
+    const KEY_IS_FORCE_ADD_HEADERS = 'keyIsForceAddHeaders';
 
     /** Settings key */
-    const KEY_IS_CHECK_HOST = 9;
+    const KEY_IS_CHECK_HOST = 'keyIsCheckHost';
 
     /**
      * @var array


### PR DESCRIPTION
This PR initializes constants with string values instead of numeric values. 

Numeric values causes problems, if the config values should be overwritten in aggregated configs.

For example:

```php
<?php
// cors.global.php

use Neomerx\Cors\Strategies\Settings;

return [
    'cors' => [
        Settings::KEY_SERVER_ORIGIN   => '192.168.0.1',
        Settings::KEY_ALLOWED_ORIGINS => [
            'some.allowed.origin' => true,
        ],
    ],
];
```

```php
<?php
// cors.local.php

use Neomerx\Cors\Strategies\Settings;

return [
    'cors' => [
        Settings::KEY_SERVER_ORIGIN   => '192.168.0.2',
        Settings::KEY_ALLOWED_ORIGINS => [
            'some.allowed.origin' => true,
        ],
    ],
];
```
If the two files are merged with an aggregator (like [Zend ConfigAggregator](https://github.com/zendframework/zend-config-aggregator)), the merged config looks like

```php
[
    'cors' => [
        0 => '192.168.0.1',
        1 => [
            'some.allowed.origin' => true,
        ],
        2 => '192.168.0.2',
        3 => [
            'some.allowed.origin' => true,
        ],
    ],
];
```

With string values the merged config works like expected

```php
[
    'cors' => [
        'keyServerOrigin' => '192.168.0.2',
        'keyAllowedOrigins' => [
            'some.allowed.origin' => true,
        ],
    ],
];
```