### PR TITLE
Update psr/log dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
   "require": {
     "php": ">=7.1.0",
     "psr/http-message": "^1.0",
-    "psr/log": "^1.0"
+    "psr/log": "^1.0 || ^2.0 || ^3.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^7.0",


### PR DESCRIPTION
It's quite important, because modern packages rely on psr/log of at least 2.0 vesrion, so adding neomerx/cors-psr7 raises confilct.