### PR TITLE
Fix PSR logger trait

### DIFF
--- a/src/Log/LoggerAwareTrait.php
+++ b/src/Log/LoggerAwareTrait.php
@@ -21,6 +21,7 @@ namespace Neomerx\Cors\Log;
  */
 
 use Psr\Log\LoggerAwareTrait as PsrLoggerAwareTrait;
+use Psr\Log\LoggerInterface;
 
 trait LoggerAwareTrait
 {
@@ -28,21 +29,21 @@ trait LoggerAwareTrait
 
     protected function logDebug(string $message, array $context = []): void
     {
-        true === $this->hasLogger() ?: $this->logger->debug($message, $context);
+        true === $this->hasLogger() && $this->logger->debug($message, $context);
     }
 
     protected function logInfo(string $message, array $context = []): void
     {
-        true === $this->hasLogger() ?: $this->logger->info($message, $context);
+        true === $this->hasLogger() && $this->logger->info($message, $context);
     }
 
     protected function logWarning(string $message, array $context = []): void
     {
-        true === $this->hasLogger() ?: $this->logger->warning($message, $context);
+        true === $this->hasLogger() && $this->logger->warning($message, $context);
     }
 
     protected function hasLogger(): bool
     {
-        return null === $this->logger;
+        return $this->logger instanceof LoggerInterface;
     }
 }


### PR DESCRIPTION
The previous implementation had the wrong result for `hasLogger` while inverting the handling in the associated trait functions. This PR reverses the logic while keeping functionality the same. Suggest minor version increment.