### PR TITLE
chore: bump `psr/http-message` to `^1.0|^2.0`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
   ],
   "require": {
     "php": ">=8.0.0",
-    "psr/http-message": "^1.0",
+    "psr/http-message": "^1.0 || ^2.0",
     "psr/log": "^3.0"
   },
   "require-dev": {


### PR DESCRIPTION
I have a project using both:

* `tuupola/cors-middleware`, and
* `psr/http-message`

and would like to bring `psr/http-message` up to ^2.0.

However, the transitive dependency of `tuupola/cors-middleware` -> `neomerx/cors-psr7` -> `psr/http-message` ^1.0 is holding that back.

Uses of `psr/http-message` in this project seem to be constrained to:

* `Psr\Http\Message\RequestInterface`

which has only changed between 1.1 and 2.0 by adding return types to the methods.